### PR TITLE
Add dev container for the example

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,3 @@
+FROM ghcr.io/hyperlight-dev/hyperlight-devcontainer:latest
+
+RUN cargo install --git https://github.com/hyperlight-dev/hyperlight-wasm hyperlight-wasm-aot

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,23 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/rust
+{
+	"name": "Rust",
+	"build": {
+        // Path is relative to the devcontainer.json file.
+        "dockerfile": "Dockerfile"
+    },
+    "remoteUser": "vscode",
+	"containerUser": "vscode",
+	"features": {
+		"ghcr.io/devcontainers/features/node:1": {}
+	},
+	"containerEnv": {
+      "DEVICE": "/dev/kvm",
+      "REMOTE_USER": "vscode",
+      "REMOTE_GROUP": "vscode"
+    },
+	"runArgs": [
+        "--device=/dev/kvm"
+    ],
+	"postStartCommand": "bash .devcontainer/setup.sh"
+}

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Change device ownership
+sudo chown -R $REMOTE_USER:$REMOTE_GROUP $DEVICE
+# resolves a npm bug related to these being set to root
+sudo chown -R vscode  "/home/vscode/.npm"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,11 @@ The [example](./example/) program loads the composed calculator/wasm component i
 
 ## Requirements
 
-To build and run this example, you need the following tools installed on your system:
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/jsturtevant/hyperlight-wasm-calculator-example/tree/dev-container)
+
+[![Open in VS Code Container](https://img.shields.io/static/v1?label=Remote%20-%20Containers&message=Open&color=blue&logo=visualstudiocode)](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/jsturtevant/hyperlight-wasm-calculator-example)
+
+To build and run this example locally, you need the following tools installed on your system:
 
 - [Rust toolchain](https://www.rust-lang.org/tools/install) including `x86_unknown-none` target
   - https://www.rust-lang.org/tools/install

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ The [example](./example/) program loads the composed calculator/wasm component i
 
 ## Requirements
 
-[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/jsturtevant/hyperlight-wasm-calculator-example/tree/dev-container)
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/hyperlight-dev/hyperlight-wasm-calculator-example/)
 
-[![Open in VS Code Container](https://img.shields.io/static/v1?label=Remote%20-%20Containers&message=Open&color=blue&logo=visualstudiocode)](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/jsturtevant/hyperlight-wasm-calculator-example)
+[![Open in VS Code Container](https://img.shields.io/static/v1?label=Remote%20-%20Containers&message=Open&color=blue&logo=visualstudiocode)](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/hyperlight-dev/hyperlight-wasm-calculator-example)
 
 To build and run this example locally, you need the following tools installed on your system:
 

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -41,7 +41,7 @@ fn main() {
     let rt = crate::bindings::register_host_functions(&mut sb, state);
     // Initialise the Wasm engine inside the sandbox
     let sb = sb.load_runtime().unwrap();
-    let sb = sb.load_module("calculator-composed.bin").unwrap();
+    let sb = sb.load_module("calculator-composed.bin").expect("missing calculator module. build the components first");
     // Wrap up the sandbox and the resources to get something which
     // we can instantiate and run methods against
     let mut wrapped = bindings::CalculatorSandbox {sb, rt};


### PR DESCRIPTION
This makes it easier to either open as a dev container or in code spaces to get started with the demo.

~Demo of it working in on my fork: https://github.com/jsturtevant/hyperlight-wasm-calculator-example~ updated the references so won't work on the fork any more

~Draft untill some of the tools are in the hyper-light wasm container (using a custom built image now)~